### PR TITLE
Fix instance_type usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.3 (Nov 29, 2023)
+* Connect the `instance_type` input to the EC2 instance created
+
 # 0.1.2 (Nov 28, 2023)
 * Added support for configuring beanstalk environment settings through capability output `settings`.
 

--- a/beanstalk.tf
+++ b/beanstalk.tf
@@ -10,7 +10,12 @@ locals {
   beanstalk_env = "${local.env_name}-${random_string.resource_suffix.result}"
 
   // Settings Reference: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
-  basic_settings = [
+  basic_settings = [    
+    {
+      namespace = "aws:ec2:instances"
+      name      = "InstanceTypes"
+      value     = join(",", [var.instance_type])
+    },
     {
       namespace = "aws:ec2:vpc"
       name      = "ELBScheme"
@@ -61,5 +66,17 @@ resource "aws_elastic_beanstalk_environment" "this" {
       name      = setting.value.name
       value     = setting.value.value
     }
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = var.minimum_instances
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = var.maximum_instances
   }
 }

--- a/beanstalk.tf
+++ b/beanstalk.tf
@@ -67,16 +67,4 @@ resource "aws_elastic_beanstalk_environment" "this" {
       value     = setting.value.value
     }
   }
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MinSize"
-    value     = var.minimum_instances
-  }
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MaxSize"
-    value     = var.maximum_instances
-  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,21 +16,3 @@ Instance Type that dictates CPU, Memory, network bandwidth, and file storage typ
 See https://aws.amazon.com/ec2/instance-types/ for EC2 instance types.
 EOF
 }
-
-variable "minimum_instances" {
-  type        = number
-  default     = 1
-  description = <<EOF
-The minimum number of instances that you want.
-See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
-EOF
-}
-
-variable "maximum_instances" {
-  type        = number
-  default     = 4
-  description = <<EOF
-The maximum number of instances that you want.
-See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
-EOF
-}

--- a/variables.tf
+++ b/variables.tf
@@ -16,3 +16,21 @@ Instance Type that dictates CPU, Memory, network bandwidth, and file storage typ
 See https://aws.amazon.com/ec2/instance-types/ for EC2 instance types.
 EOF
 }
+
+variable "minimum_instances" {
+  type        = number
+  default     = 1
+  description = <<EOF
+The minimum number of instances that you want.
+See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
+EOF
+}
+
+variable "maximum_instances" {
+  type        = number
+  default     = 4
+  description = <<EOF
+The maximum number of instances that you want.
+See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
+EOF
+}


### PR DESCRIPTION
<del>In addition to adding config for min/max instances,</del> this also fixes a bug with the `instance_type` configuration by assigning it to the `aws:ec2:instances/InstanceTypes` variable.