### PR TITLE
Enable CloudWatch logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.4 (Nov 29, 2023)
+* Enable CloudWatch logging
+
 # 0.1.3 (Nov 29, 2023)
 * Connect the `instance_type` input to the EC2 instance created
 

--- a/beanstalk.tf
+++ b/beanstalk.tf
@@ -45,6 +45,11 @@ locals {
       namespace = "aws:autoscaling:launchconfiguration"
       name      = "SecurityGroups"
       value     = join(",", [aws_security_group.this.id])
+    },
+    {
+      namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+      name      = "StreamLogs"
+      value     = true
     }
   ]
   cap_settings = lookup(local.capabilities, "settings", [])

--- a/log-reader.tf
+++ b/log-reader.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_user" "log_reader" {
+  name = "log-reader-${local.resource_name}"
+  tags = local.tags
+}
+
+resource "aws_iam_access_key" "log_reader" {
+  user = aws_iam_user.log_reader.name
+}
+
+resource "aws_iam_user_policy" "log_reader" {
+  name   = "AllowReadLogs"
+  user   = aws_iam_user.log_reader.name
+  policy = data.aws_iam_policy_document.log_reader.json
+}
+
+data "aws_iam_policy_document" "log_reader" {
+  statement {
+    sid    = "AllowReadLogs"
+    effect = "Allow"
+
+    actions = [
+      "logs:Get*",
+      "logs:List*",
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:TestMetricFilter",
+      "logs:Filter*"
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.this.arn}:log-stream:*"
+    ]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,6 +45,26 @@ output "environment_id" {
   description = "string ||| The ID of the this Elastic Beanstalk Environment"
 }
 
+output "log_provider" {
+  value       = "cloudwatch"
+  description = "string ||| "
+}
+
+output "log_group_name" {
+  value       = module.logs.name // TODO: fix this. how do I get the log group name that's created from Terraform?
+  description = "string ||| "
+}
+
+output "log_reader" {
+  value = {
+    name       = try(aws_iam_user.log_reader.name, "")
+    access_key = try(aws_iam_access_key.log_reader.id, "")
+    secret_key = try(aws_iam_access_key.log_reader.secret, "")
+  }
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
+  sensitive   = true
+}
+
 output "private_urls" {
   value       = local.private_urls
   description = "list(string) ||| A list of URLs only accessible inside the network"

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "log_provider" {
 }
 
 output "log_group_name" {
-  value       = module.logs.name // TODO: fix this. how do I get the log group name that's created from Terraform?
+  value       = "/aws/elasticbeanstalk/${aws_elastic_beanstalk_application.this.name}"
   description = "string ||| "
 }
 


### PR DESCRIPTION
This turns on the flag for [CloudWatch logging](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-cloudwatchlogs)