### PR TITLE
Format logging resource

### DIFF
--- a/log-reader.tf
+++ b/log-reader.tf
@@ -1,3 +1,6 @@
+locals {
+  log_group = "/aws/elasticbeanstalk/${aws_elastic_beanstalk_application.this.name}/*"
+}
 resource "aws_iam_user" "log_reader" {
   name = "log-reader-${local.resource_name}"
   tags = local.tags
@@ -28,7 +31,7 @@ data "aws_iam_policy_document" "log_reader" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:log-group:*:log-stream:*"
+      "arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.log_group}:log-stream:*"
     ]
   }
 }

--- a/log-reader.tf
+++ b/log-reader.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "log_reader" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.this.arn}:log-stream:*"
+      "arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:log-group:*:log-stream:*"
     ]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "log_provider" {
 }
 
 output "log_group_name" {
-  value       = "/aws/elasticbeanstalk/${aws_elastic_beanstalk_application.this.name}/*"
+  value       = "${local.log_group}"
   description = "string ||| A wildcard pattern that matches a list of AWS Cloudwatch logs groups containing application logs"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "log_provider" {
 }
 
 output "log_group_name" {
-  value       = "${local.log_group}"
+  value       = local.log_group
   description = "string ||| A wildcard pattern that matches a list of AWS Cloudwatch logs groups containing application logs"
 }
 


### PR DESCRIPTION
The previous iteration was failing for an invalid reference. This change manually creates the ARN string for the IAM log reader policy.

<img width="1130" alt="image" src="https://github.com/nullstone-modules/aws-beanstalk-app/assets/16509697/184ac616-1ddb-4c42-b7cc-acda55bcb66f">
