### PR TITLE
Add capability env vars/secrets

### DIFF
--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,6 +1,9 @@
 // This file is replaced by code-generation using 'capabilities.tf.tmpl'
 // This file helps app module creators define a contract for what types of capability outputs are supported.
 locals {
+
+  cap_env_vars = {}
+  cap_secrets  = {}
   capabilities = {
     // settings is a list of settings that are configured on aws_elastic_beanstalk_environment
     // Reference: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-ec2instances

--- a/env_vars.tf
+++ b/env_vars.tf
@@ -27,8 +27,8 @@ locals {
     NULLSTONE_COMMIT_SHA    = data.ns_app_env.this.commit_sha
   })
 
-  input_env_vars = merge(local.standard_env_vars, var.env_vars)
-  input_secrets  = var.secrets
+  input_env_vars = merge(local.standard_env_vars, local.cap_env_vars, var.env_vars)
+  input_secrets  = merge(local.cap_secrets, var.secrets)
 }
 
 data "ns_env_variables" "this" {


### PR DESCRIPTION
Previously capability environment variables and secrets were not pulled in, but this is needed in order to integrate things like Postgres.

This facilitates that support by merging the values with the existing `env_vars` plan.