### PR TITLE
Update instance profile policy and add adminer

### DIFF
--- a/adminer.tf
+++ b/adminer.tf
@@ -1,0 +1,26 @@
+resource "aws_iam_user" "adminer" {
+  name = "adminer-${local.resource_name}"
+  tags = local.tags
+}
+
+resource "aws_iam_access_key" "adminer" {
+  user = aws_iam_user.adminer.name
+}
+
+resource "aws_iam_user_policy" "adminer" {
+  user   = aws_iam_user.adminer.name
+  policy = data.aws_iam_policy_document.adminer.json
+}
+
+data "aws_iam_policy_document" "adminer" {
+  statement {
+    sid     = "AllowSSMSession"
+    effect  = "Allow"
+    actions = ["ssm:StartSession"]
+
+    resources = [
+      aws_instance.this.arn,
+      "arn:aws:ssm:us-east-1::document/AWS-StartSSHSession",
+    ]
+  }
+}

--- a/adminer.tf
+++ b/adminer.tf
@@ -16,11 +16,7 @@ data "aws_iam_policy_document" "adminer" {
   statement {
     sid     = "AllowSSMSession"
     effect  = "Allow"
-    actions = ["ssm:StartSession"]
-
-    resources = [
-      aws_instance.this.arn,
-      "arn:aws:ssm:us-east-1::document/AWS-StartSSHSession",
-    ]
+    actions = ["elasticbeanstalk:DescribeEnvironmentResources"]
+    resources = [aws_elastic_beanstalk_application.this.arn]
   }
 }

--- a/adminer.tf
+++ b/adminer.tf
@@ -14,9 +14,35 @@ resource "aws_iam_user_policy" "adminer" {
 
 data "aws_iam_policy_document" "adminer" {
   statement {
-    sid     = "AllowSSMSession"
-    effect  = "Allow"
-    actions = ["elasticbeanstalk:DescribeEnvironmentResources"]
-    resources = [aws_elastic_beanstalk_application.this.arn]
+    sid       = "ReadEnvironment"
+    effect    = "Allow"
+    actions   = ["elasticbeanstalk:DescribeEnvironmentResources"]
+    resources = [local.env_arn]
+  }
+
+  statement {
+    sid       = "EnableSSMSession"
+    effect    = "Allow"
+    actions   = ["ssm:StartSession"]
+    resources = ["arn:aws:ssm:us-east-1::document/AWS-StartSSHSession"]
+  }
+
+  statement {
+    sid       = "AllowSSMSession"
+    effect    = "Allow"
+    actions   = ["ssm:StartSession"]
+    resources = ["arn:aws:ec2:*:*:instance/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/elasticbeanstalk:application-name"
+      values   = [local.app_name]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/elasticbeanstalk:environment-name"
+      values   = [local.beanstalk_name]
+    }
   }
 }

--- a/aws.tf
+++ b/aws.tf
@@ -1,2 +1,7 @@
 data "aws_region" "this" {}
 data "aws_caller_identity" "this" {}
+
+locals {
+  region     = data.aws_region.this.name
+  account_id = data.aws_caller_identity.this.account_id
+}

--- a/beanstalk.tf
+++ b/beanstalk.tf
@@ -55,6 +55,9 @@ locals {
   cap_settings = lookup(local.capabilities, "settings", [])
   env_vars_settings = [for k, v in local.all_env_vars : {namespace = "aws:elasticbeanstalk:application:environment", name = k, value = v }]
   all_settings = { for setting in concat(local.basic_settings, local.cap_settings, local.env_vars_settings) : "${setting.namespace}/${setting.name}" => setting }
+  app_name = aws_elastic_beanstalk_application.this.name
+  beanstalk_name = aws_elastic_beanstalk_environment.this.name
+  env_arn = "arn:aws:elasticbeanstalk:${local.region}:${local.account_id}:environment/${local.app_name}/${local.beanstalk_name}"
 }
 
 resource "aws_elastic_beanstalk_environment" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,17 @@ output "region" {
   description = "string ||| The region the lambda was created."
 }
 
+output "adminer" {
+  value = {
+    name       = aws_iam_user.adminer.name
+    access_key = aws_iam_access_key.adminer.id
+    secret_key = aws_iam_access_key.adminer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to admin the EC2 instance."
+  sensitive   = true
+}
+
 output "artifacts_bucket_arn" {
   value       = aws_s3_bucket.artifacts.arn
   description = "string ||| The ARN of the created S3 bucket used for deployment artifacts."

--- a/role.tf
+++ b/role.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "this" {
 // This policy enables SSM on the instance
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_role_policy_attachment" "docker" {

--- a/role.tf
+++ b/role.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "this" {
 // This policy enables SSM on the instance
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2RoleforSSM"
 }
 
 resource "aws_iam_role_policy_attachment" "docker" {

--- a/role.tf
+++ b/role.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "this" {
 // This policy enables SSM on the instance
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 resource "aws_iam_role_policy_attachment" "docker" {


### PR DESCRIPTION
This updates two sections:
1. Updates the policy on the Instance profile
  - The `AmazonSSMManagedInstanceCore` is a subset of `AmazonEC2RoleforSSM`
3. Adds an `adminer` IAM user and associated output