### PR TITLE
Update adminer policies

### DIFF
--- a/adminer.tf
+++ b/adminer.tf
@@ -19,6 +19,22 @@ data "aws_iam_policy_document" "adminer" {
     actions   = ["elasticbeanstalk:DescribeEnvironmentResources"]
     resources = [local.env_arn]
   }
+  statement {
+    sid       = "ReadAutoScaling"
+    effect    = "Allow"
+    actions   = ["autoscaling:DescribeAutoScalingGroups"]
+    resources = ["arn:aws:autoscaling:${local.region}:${local.account_id}:autoScalingGroup:*:autoScalingGroupName/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/elasticbeanstalk:application-name"
+      values   = [local.app_name]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/elasticbeanstalk:environment-name"
+      values   = [local.beanstalk_name]
+    }
+  }
 
   statement {
     sid       = "EnableSSMSession"
@@ -35,13 +51,13 @@ data "aws_iam_policy_document" "adminer" {
 
     condition {
       test     = "StringEquals"
-      variable = "ec2:ResourceTag/elasticbeanstalk:application-name"
+      variable = "aws:ResourceTag/elasticbeanstalk:application-name"
       values   = [local.app_name]
     }
 
     condition {
       test     = "StringEquals"
-      variable = "ec2:ResourceTag/elasticbeanstalk:environment-name"
+      variable = "aws:ResourceTag/elasticbeanstalk:environment-name"
       values   = [local.beanstalk_name]
     }
   }

--- a/adminer.tf
+++ b/adminer.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "adminer" {
     resources = ["arn:aws:autoscaling:${local.region}:${local.account_id}:autoScalingGroup:*:autoScalingGroupName/*"]
     condition {
       test     = "StringEquals"
-      variable = "aws:ResourceTag/elasticbeanstalk:application-name"
+      variable = "aws:ResourceTag/Block"
       values   = [local.app_name]
     }
     condition {
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "adminer" {
 
     condition {
       test     = "StringEquals"
-      variable = "aws:ResourceTag/elasticbeanstalk:application-name"
+      variable = "aws:ResourceTag/Block"
       values   = [local.app_name]
     }
 

--- a/adminer.tf
+++ b/adminer.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "adminer" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/Block"
-      values   = [local.app_name]
+      values   = [local.block_name]
     }
     condition {
       test     = "StringEquals"
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "adminer" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/Block"
-      values   = [local.app_name]
+      values   = [local.block_name]
     }
 
     condition {


### PR DESCRIPTION
This PR:
- adds the permission to describe the Auto Scaling Groups based on given tags
- updates the variable condition to use the `aws` resource tag instead of ec2


~~Prior to merging this PR, we need to resolve the tag creation. Currently, the resources aren't created with the `elasticbeanstalk:application-name` tag~~

I opted to change this to using the `Block` tag instead since `application-name` isn't [automatically created like `environment-name` is](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.tagging.html)