### PR TITLE
Add permission for `process` command during `CreateApplicationVersion`

### DIFF
--- a/deployer.tf
+++ b/deployer.tf
@@ -93,6 +93,7 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "s3:DeleteObject",
       "s3:GetBucketPolicy",
       "s3:CreateBucket",
+      "s3:GetBucketLocation",
     ]
 
     resources = [


### PR DESCRIPTION
This fixes the permissions error when running the command `nullstone push ...` to a beanstalk environment. 

This is necessary because we're using the [`process`](https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/create-application-version.html) flag when running the `CreateApplicationVersion` command