### PR TITLE
Allow create log group for deployer

### DIFF
--- a/deployer.tf
+++ b/deployer.tf
@@ -145,6 +145,6 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "logs:CreateLogGroup",
       "logs:PutRetentionPolicy"
     ]
-    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/var/log/*:log-stream"]
+    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/*:log-stream"]
   }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
   statement {
     sid       = "AllowLogsForBeanstalk"
     effect    = "Allow"
-    actions   = "logs:CreateLogGroup"
+    actions   = ["logs:CreateLogGroup"]
     resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/var/log/*:log-stream"]
   }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -136,4 +136,11 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "autoscaling:PutNotificationConfiguration"
     ]
   }
+
+  statement {
+    sid       = "AllowLogsForBeanstalk"
+    effect    = "Allow"
+    actions   = "logs:CreateLogGroup"
+    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/var/log/*:log-stream"]
+  }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -134,7 +134,8 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "autoscaling:ResumeProcesses",
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeLaunchConfigurations",
-      "autoscaling:PutNotificationConfiguration"
+      "autoscaling:PutNotificationConfiguration",
+      "elasticloadbalancing:DescribeLoadBalancers"
     ]
   }
 

--- a/deployer.tf
+++ b/deployer.tf
@@ -145,6 +145,6 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "logs:CreateLogGroup",
       "logs:PutRetentionPolicy"
     ]
-    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/*:log-stream"]
+    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/*:*"]
   }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -94,6 +94,7 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "s3:GetBucketPolicy",
       "s3:CreateBucket",
       "s3:GetBucketLocation",
+      "s3:GetObjectVersion"
     ]
 
     resources = [

--- a/deployer.tf
+++ b/deployer.tf
@@ -147,6 +147,6 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "logs:CreateLogGroup",
       "logs:PutRetentionPolicy"
     ]
-    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/*:*"]
+    resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:${local.log_group}"]
   }
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -116,6 +116,7 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
       "cloudformation:DescribeStacks",
       "cloudformation:UpdateStack",
       "cloudformation:CancelUpdateStack",
+      "cloudformation:ListStackResources",
     ]
   }
 

--- a/deployer.tf
+++ b/deployer.tf
@@ -141,7 +141,10 @@ data "aws_iam_policy_document" "deployer-beanstalk" {
   statement {
     sid       = "AllowLogsForBeanstalk"
     effect    = "Allow"
-    actions   = ["logs:CreateLogGroup"]
+    actions   = [
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy"
+    ]
     resources = ["arn:aws:logs:${data.aws_region.this.name}:*:log-group:/aws/elasticbeanstalk/${local.beanstalk_env}/var/log/*:log-stream"]
   }
 }

--- a/log-reader.tf
+++ b/log-reader.tf
@@ -1,5 +1,5 @@
 locals {
-  log_group = "/aws/elasticbeanstalk/${aws_elastic_beanstalk_application.this.name}/*"
+  log_group = "/aws/elasticbeanstalk/${local.beanstalk_env}/*"
 }
 resource "aws_iam_user" "log_reader" {
   name = "log-reader-${local.resource_name}"


### PR DESCRIPTION
This is still a work in progress. There are some other errors that are occurring as well during launch.

When using the `nullstone launch` CLI command, there was an issue deploying the application. It's not clear why this needs the `deployer` user instead of the beanstalk user, but so it is with AWS

<img width="606" alt="image" src="https://github.com/nullstone-modules/aws-beanstalk-app/assets/16509697/3b102494-fd60-4648-9561-c72395fe5728">
